### PR TITLE
Add QT dependency patch for aarch64

### DIFF
--- a/depends/patches/qt/aarch64-qmake.conf
+++ b/depends/patches/qt/aarch64-qmake.conf
@@ -1,0 +1,20 @@
+MAKEFILE_GENERATOR      = UNIX
+CONFIG                 += incremental
+QMAKE_INCREMENTAL_STYLE = sublib
+
+include(../common/linux.conf)
+include(../common/gcc-base-unix.conf)
+include(../common/g++-unix.conf)
+
+# modifications to g++.conf
+QMAKE_CC                = aarch64-linux-gnu-gcc
+QMAKE_CXX               = aarch64-linux-gnu-g++
+QMAKE_LINK              = aarch64-linux-gnu-g++
+QMAKE_LINK_SHLIB        = aarch64-linux-gnu-g++
+
+# modifications to linux.conf
+QMAKE_AR                = aarch64-linux-gnu-ar cqs
+QMAKE_OBJCOPY           = aarch64-linux-gnu-objcopy
+QMAKE_NM                = aarch64-linux-gnu-nm -P
+QMAKE_STRIP             = aarch64-linux-gnu-strip
+load(qt_config)


### PR DESCRIPTION
When building GGN Daemon and QT wallet on Ubuntu 18.04, with aarch 64-bit, I had to built the dependencies in depends first with `cd depends && make` it threw an error `error: aarch64-qmake.conf not found`
This PR adds the file so you can built successfully.
(Tested on Ubuntu 18.04.2, aarch 64bit, GCC 7)